### PR TITLE
Do not run the bonus spec in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ workflows:
     jobs:
       - cypress/run:
           start: npm start
+          spec: cypress/integration/index.test.js
           post-steps:
             - store_test_results:
                 path: ./reports/junit


### PR DESCRIPTION
Add a `spec` key to the config so that only the main test runs, not the bonus.