### PR TITLE
Run node and cypress tests in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,65 @@
 version: 2.1
 orbs:
   cypress: cypress-io/cypress@1
-workflows:
+
+jobs:
   build:
+    docker:
+      - image: cimg/node:15.11.0
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - dependency-cache-1-{{ checksum "package-lock.json" }}
+      - run: npm install
+      - save_cache:
+          paths:
+            - node_modules
+          key: dependency-cache-1-{{ checksum "package-lock.json" }}
+      - persist_to_workspace:
+          root: "."
+          paths:
+            - node_modules
+
+  test:
+    docker:
+      - image: cimg/node:15.11.0
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - attach_workspace:
+          at: "."
+      - run: npm run test
+      - store_test_results:
+          path: ./reports/junit
+      - store_artifacts:
+          path: ./reports/junit
+      - run:
+          name: Notify Test Results
+          command: node ./scripts/parseJunit.js
+          when: always
+
+  cypress/run:
+    start: npm start
+    spec: cypress/integration/index.test.js
+    post-steps:
+      - store_test_results:
+          path: ./reports/junit
+      - store_artifacts:
+          path: cypress/videos
+      - store_artifacts:
+          path: cypress/screenshots
+      - run:
+          name: Notify Test Results
+          command: node ./scripts/parseJunit.js
+          when: always
+
+workflows:
+  build_and_test:
     jobs:
-      - cypress/run:
-          start: npm start
-          spec: cypress/integration/index.test.js
-          post-steps:
-            - store_test_results:
-                path: ./reports/junit
-            - store_artifacts:
-                path: cypress/videos
-            - store_artifacts:
-                path: cypress/screenshots
-            - run:
-                name: Notify Test Results
-                command: node ./scripts/parseJunit.js
-                when: always
+      - build
+      - test:
+          requires:
+            - build
+      - cypress/run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,21 +40,6 @@ jobs:
           command: node ./scripts/parseJunit.js
           when: always
 
-  cypress/run:
-    start: npm start
-    spec: cypress/integration/index.test.js
-    post-steps:
-      - store_test_results:
-          path: ./reports/junit
-      - store_artifacts:
-          path: cypress/videos
-      - store_artifacts:
-          path: cypress/screenshots
-      - run:
-          name: Notify Test Results
-          command: node ./scripts/parseJunit.js
-          when: always
-
 workflows:
   build_and_test:
     jobs:
@@ -62,4 +47,17 @@ workflows:
       - test:
           requires:
             - build
-      - cypress/run
+      - cypress/run:
+          start: npm start
+          spec: cypress/integration/index.test.js
+          post-steps:
+            - store_test_results:
+                path: ./reports/junit
+            - store_artifacts:
+                path: cypress/videos
+            - store_artifacts:
+                path: cypress/screenshots
+            - run:
+                name: Notify Test Results
+                command: node ./scripts/parseJunit.js
+                when: always

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ cypress/videos
 reports/
 cypress/integration/examples
 cypress/fixtures/example.json
+
+# junit
+junit*.xml

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Should include:
 - `npm install` to install dependencies
 - `npm run cypress` to open the cypress testing window
 - `npm test` to run jest / node tests
-- `npm run test:bonus` to run jest / node tests **including the bonus tests**
+- `npm run test:bonus` to run jest / node tests _including the bonus tests_
 
 > _Note_: Remember to `git add`, `git commit` and `git push` regularly
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Should include:
 - `npm install` to install dependencies
 - `npm run cypress` to open the cypress testing window
 - `npm test` to run jest / node tests
+- `npm run test:bonus` to run jest / node tests **including the bonus tests**
 
 > _Note_: Remember to `git add`, `git commit` and `git push` regularly
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,13 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "react-assignment-template",
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.11.9",
         "@testing-library/react": "^11.2.5",
         "@testing-library/user-event": "^12.8.3",
+        "jest-junit": "^12.0.0",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "react-scripts": "4.0.3",
@@ -11775,6 +11777,58 @@
         "node": ">=8"
       }
     },
+    "node_modules/jest-junit": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-12.0.0.tgz",
+      "integrity": "sha512-+8K35LlboWiPuCnXSyiid7rFdxNlpCWWM20WEYe6IZH6psfUWKZmSpSRQ5tk0C0cBeDsvsnIzcef5mYhyJsbug==",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^5.2.0",
+        "uuid": "^3.3.3",
+        "xml": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/jest-junit/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jest-junit/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-junit/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jest-junit/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/jest-leak-detector": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz",
@@ -22540,6 +22594,11 @@
         }
       }
     },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
+    },
     "node_modules/xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
@@ -31797,6 +31856,42 @@
         }
       }
     },
+    "jest-junit": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-12.0.0.tgz",
+      "integrity": "sha512-+8K35LlboWiPuCnXSyiid7rFdxNlpCWWM20WEYe6IZH6psfUWKZmSpSRQ5tk0C0cBeDsvsnIzcef5mYhyJsbug==",
+      "requires": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^5.2.0",
+        "uuid": "^3.3.3",
+        "xml": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
+      }
+    },
     "jest-leak-detector": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz",
@@ -40295,6 +40390,11 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
       "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
       "requires": {}
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^12.8.3",
+    "jest-junit": "^12.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-scripts": "4.0.3",
@@ -14,7 +15,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --ci --reporters=default --reporters=jest-junit",
     "eject": "react-scripts eject",
     "cypress": "./node_modules/.bin/cypress open"
   },
@@ -41,5 +42,10 @@
     "fast-glob": "^3.2.5",
     "junitxml-to-javascript": "^1.1.4",
     "node-fetch": "^2.6.1"
+  },
+  "jest-junit": {
+    "suiteNameTemplate": "{filename}",
+    "classNameTemplate": "{filename}",
+    "outputDirectory": "reports/junit"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --ci --reporters=default --reporters=jest-junit",
+    "test": "react-scripts test --ci --reporters=default --reporters=jest-junit --testPathIgnorePatterns=bonus",
+    "test:bonus": "react-scripts test",
     "eject": "react-scripts eject",
     "cypress": "./node_modules/.bin/cypress open"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -37,11 +37,8 @@ const donations = [
   },
 ];
 
-
 export default class App extends React.Component {
   render() {
-    console.log(donations);
-
     return (
       <>
         <TopBar />

--- a/src/Components/DonationForm.js
+++ b/src/Components/DonationForm.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+const DonationForm = () => {
+  return null;
+};
+
+export default DonationForm;

--- a/src/Components/Progress.js
+++ b/src/Components/Progress.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Progress = () => {
+  return null;
+};
+
+export default Progress;

--- a/src/Components/RecentDonations.js
+++ b/src/Components/RecentDonations.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+const RecentDonations = () => {
+  return null;
+};
+
+export default RecentDonations;

--- a/src/Components/TopBar.js
+++ b/src/Components/TopBar.js
@@ -1,10 +1,14 @@
 import React from "react";
 
-export default function TopBar() {
+const TopBar = () => {
   return (
     <section className="jumbotron text-center">
       <h1 className="jumbotron-heading">Go Fund Me</h1>
-      <p className="lead text-muted">Help me go on a vacation to a beach somewhere</p>
+      <p className="lead text-muted">
+        Help me go on a vacation to a beach somewhere
+      </p>
     </section>
   );
-}
+};
+
+export default TopBar;


### PR DESCRIPTION
Update config based on the build-test workflow in the React Intro Lab.

Additional changes:
- Add empty component files so that all the jest tests are runnable in circle and we get accurate results.
- Add a flag to avoid running the bonus test on circle, and add a separate script in `package.json` to run all jest tests, including the bonus
- Some small cleanups to the existing code:
  - Use ES6 syntax for TopBar function component
  - Remove `console.log` from `App.js`

Remaining TODOs:
- [x] Delete the `TopBar` jest test and delete the assertions about TopBar from the cypress test? I'm not sure where we landed on that @myrasmith? I'm torn. It's always good to not have tests pass when no code has been written by the learner. BUT there is a plus to keeping those tests to prevent regressions. (This PR)
- [x] Same question about `App.test.js` which currently passes. (This PR)
- [x] Have the slack notification for each test type specifically state if it is node or cypress, then turn slack notifications back on. (Follow up PR 1)
- [x] Have the jobs run sequentially, then persist all of the junit xml files to a final job that parses, tallies, and sends only one notification. (Follow up PR 2)

