### PR TITLE
Specify test type (jest or cypress) in slack notify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
             - node_modules
 
   jest_test:
+    name: Jest Tests
     docker:
       - image: cimg/node:15.11.0
     working_directory: ~/repo
@@ -48,6 +49,7 @@ workflows:
           requires:
             - build
       - cypress/run:
+          name: Cypress Tests
           start: npm start
           spec: cypress/integration/index.test.js
           post-steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ jobs:
             - node_modules
 
   jest_test:
-    name: Jest Tests
     docker:
       - image: cimg/node:15.11.0
     working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           paths:
             - node_modules
 
-  test:
+  jest_test:
     docker:
       - image: cimg/node:15.11.0
     working_directory: ~/repo
@@ -44,7 +44,7 @@ workflows:
   build_and_test:
     jobs:
       - build
-      - test:
+      - jest_test:
           requires:
             - build
       - cypress/run:

--- a/scripts/notifySlack.js
+++ b/scripts/notifySlack.js
@@ -8,9 +8,10 @@ const username =
 
 const prUrl = process.env["CIRCLE_PULL_REQUEST"];
 const circleJobUrl = process.env["CIRCLE_BUILD_URL"];
+const testType = process.env["CIRCLE_JOB"];
 
 const notifyPass = async (numSuites) => {
-  const msg = `🎉 ✅ Yay! *${username}* passed all ${numSuites} tests in ${repoName}!`;
+  const msg = `🎉 ✅ Yay! *${username}* passed all ${numSuites} ${testType} tests in ${repoName}!`;
   console.log(msg);
   await postToSlack(webhookUrl, msg);
 };
@@ -18,7 +19,7 @@ const notifyPass = async (numSuites) => {
 const notifyFail = async ({ numSuites, passedSuites, failedSuites }) => {
   const msg = `😿 🚫 *${username}* passed ${
     passedSuites.length
-  } / ${numSuites} tests for ${repoName}
+  } / ${numSuites} ${testType} tests for ${repoName}
 Failing tests:
 
 • ${failedSuites.join(" \n • ")}

--- a/scripts/parseJunit.js
+++ b/scripts/parseJunit.js
@@ -22,7 +22,7 @@ const failedSuites = [];
 const passed = (suite) => suite.succeeded === suite.tests;
 
 const parseAllFiles = async () => {
-  const glob = __dirname + "/../reports/junit/junit-*.xml";
+  const glob = __dirname + "/../reports/junit/junit*.xml";
   const fileNames = fg.sync(glob);
   numSuites = fileNames.length;
 

--- a/scripts/parseJunit.js
+++ b/scripts/parseJunit.js
@@ -36,7 +36,9 @@ const parseAllFiles = async () => {
       passedSuites.push(testsuites[0].name);
     } else {
       let failed = testsuites.filter((ts) => !passed(ts));
-      failedSuites.push(failed[0].name);
+      failed.forEach((ts) => {
+        failedSuites.push(ts.name);
+      });
     }
   }
 


### PR DESCRIPTION
Uses the `CIRCLE_JOB` built-in envvar to give more specificity to the slack notification. Will note if the run was for jest tests or for cypress tests. Also fixed some issues that prevented listing all of the failing specs (not just the first one).

I would still like to do better than this by persisting all junit xml result files to the workspace and then parsing and reporting the total results only once. However, I think we will need a diffeerent strategy to achieve this goal. Circle does let you configure jobs in a DAG, so in theory a parse-and-notify job could be set to run last. Unfortunately, from the docs it looks like Circle requires the previous jobs to complete **successfully** in order for the next job in the DAG to run. This makes sense for most users (don't run the deploy job if the test job failed) but in our use case we want to run parse-and-notify even if (especially if) some of the tests failed.

Here are a few examples of Circle CI asking for and not getting this feature. (Note it is possible to force a step within a job to run even after the previous step fails, but what we want is to force a **job** in a **workflow** to run even if the prior job failed.)
https://discuss.circleci.com/t/continue-running-other-jobs-after-required-job-fails/24334
https://discuss.circleci.com/t/running-a-job-step-even-if-the-build-fails/31494
https://discuss.circleci.com/t/running-a-different-job-if-the-previous-succeeds-or-fails/29075/7

So for now the solution will have to be more notification spam and regrouping on the bigger goals.